### PR TITLE
Fixed to handlebars 3.0.2

### DIFF
--- a/webapp/package.json.amd64
+++ b/webapp/package.json.amd64
@@ -6,7 +6,7 @@
   "dependencies": {
     "body-parser": "^1.18.3",
     "express": "^4.16.3",
-    "express-handlebars": "^3.0.0",
+    "express-handlebars": "3.0.2",
     "fs": "^0.0.1-security",
     "ps-tree": "^1.1.0",
     "wrtc": "^0.1.6",

--- a/webapp/package.json.arm
+++ b/webapp/package.json.arm
@@ -6,7 +6,7 @@
   "dependencies": {
     "body-parser": "^1.18.3",
     "express": "^4.16.3",
-    "express-handlebars": "^3.0.0",
+    "express-handlebars": "3.0.2",
     "fs": "^0.0.1-security",
     "ps-tree": "^1.1.0",
     "ws": "^5.2.2"


### PR DESCRIPTION
Version 3.1.0 of handlebars changed the expected folder layout of layouts and views, and that didn't work with our file structure. Perhaps it's safer to stick to a specific version?